### PR TITLE
Improved aliases

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -75,20 +75,23 @@ void print_aliases(const alias_t *head)
  *
  * Return: 0 if alias was found and removed successfully, else 1
  */
-int unalias(alias_t **head, char **command)
+int unalias(alias_t **head, char *command)
 {
 	alias_t *current, *prev;
 	size_t i;
-	char *name;
+	char **names;
 	int exit_code = 1; /* assume failure by default */
 
+	names = _strtok(command, NULL);
+	if (names == NULL)
+		return (-1);
+
 	current = *head;
-	for (i = 1; command[i] != NULL; i++)
+	for (i = 1; names[i] != NULL; i++)
 	{
-		name = strtok(command[i], "=");
 		while (current != NULL)
 		{
-			if (!_strcmp(current->name, name))
+			if (!_strcmp(current->name, names[i]))
 			{
 				if (current == *head)
 					*head = (*head)->next;
@@ -106,10 +109,12 @@ int unalias(alias_t **head, char **command)
 
 		if (exit_code != 0)
 		{
-			dprintf(2, "unalias: %s not found\n", name);
+			dprintf(2, "unalias: %s not found\n", names[i]);
 			exit_code = 1;
 		}
+		safe_free(names[i]);
 	}
+	free_str(names);
 	return (exit_code);
 }
 

--- a/builtins_handler.c
+++ b/builtins_handler.c
@@ -12,17 +12,18 @@
  * Return: exit code
  */
 int handle_builtin(char **sub_command, char **commands, char *line,
-		alias_t *aliases, path_t *path_list, int exit_code)
+				   alias_t *aliases, path_t *path_list, int exit_code)
 {
-	if (!_strcmp(sub_command[0], "env") || !_strcmp(sub_command[0], "printenv"))
+	if (!_strcmp(sub_command[0], "env") ||
+		!_strcmp(sub_command[0], "printenv"))
 	{
 		_printenv();
 		return (0);
 	}
 	else if (!_strcmp(sub_command[0], "exit"))
 	{
-		return (handle_exit(sub_command[1], exit_code, multi_free,
-					sub_command, commands, line, &path_list, &aliases));
+		return (handle_exit(sub_command[1], exit_code, multi_free, sub_command,
+							commands, line, &path_list, &aliases));
 	}
 
 	/* let's handle the builtin 'cd' command */
@@ -33,7 +34,7 @@ int handle_builtin(char **sub_command, char **commands, char *line,
 	{
 		if (sub_command[1] && sub_command[2])
 			return (setenv(sub_command[1], sub_command[2], 1));
-		return (1); /* inavlid number of parameters received */
+		return (1); /* invalid number of parameters received */
 	}
 	else if (!_strcmp(sub_command[0], "unsetenv"))
 		return (_unsetenv(sub_command[1]));

--- a/parser.c
+++ b/parser.c
@@ -23,7 +23,7 @@ int parse_line(char *line, path_t *path_list)
 	/* first of all, let's get rid of all comments */
 	line = handle_comments(line);
 
-	/* now let's all the commands provided by the user */
+	/* now let's tokenize all the commands provided by the user */
 	commands = _strtok(line, "\n;");
 	if (commands == NULL)
 	{
@@ -33,6 +33,7 @@ int parse_line(char *line, path_t *path_list)
 
 	exit_code = parse(commands, path_list, line);
 	free_str(commands);
+
 	return (exit_code);
 }
 
@@ -136,7 +137,7 @@ void parse_helper(char **commands, char **sub_command, path_t *path_list,
 	if (!_strcmp(sub_command[0], "alias") ||
 		!_strcmp(sub_command[0], "unalias"))
 	{
-		exit_code = handle_alias(&aliases, sub_command);
+		exit_code = handle_alias(&aliases, commands[index]);
 		free_str(sub_command);
 		return;
 	}
@@ -144,10 +145,10 @@ void parse_helper(char **commands, char **sub_command, path_t *path_list,
 	alias_value = get_alias(aliases, sub_command[0]);
 	if (alias_value != NULL)
 	{
-		safe_free(sub_command[0]);
-		sub_command[0] = _strdup(alias_value);
+		build_alias_cmd(&sub_command, alias_value);
 		safe_free(alias_value);
 	}
+
 	exit_code = handle_builtin(sub_command, commands, line, aliases, path_list,
 							   exit_code);
 	if (exit_code != NOT_BUILTIN)

--- a/shell.h
+++ b/shell.h
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <regex.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,14 +15,16 @@
 
 /* macros */
 
-#define BUFF_SIZE 1024
-#define SPACE ' '
-#define CMD_NOT_FOUND 127
-#define PROMPT_SIZE 4096
-#define PATH_SIZE 2048
-#define NOT_BUILTIN 18
-#define RUNNING 1
-#define CMD_ERR 2
+#define BUFF_SIZE			1024
+#define SPACE				' '
+#define CMD_NOT_FOUND		127
+#define PROMPT_SIZE			4096
+#define PATH_SIZE			2048
+#define NOT_BUILTIN			18
+#define RUNNING				1
+#define CMD_ERR				2
+#define MAX_ALIAS_LENGTH	50
+#define MAX_VALUE_LENGTH	2048
 
 /* function macros */
 
@@ -30,6 +33,7 @@
 #define isalpha(c) (((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z'))
 #define isnegative(c) (((c) == '-') ? -1 : 1)
 #define issign(c) ((c) == '-' || (c) == '+')
+#define isquote(c) ((c) == '"' || (c) == '\'')
 
 /* string handlers */
 
@@ -40,6 +44,8 @@ char *_strrchr(const char *s, int c);
 char *_strcpy(char *dest, const char *src);
 char *_strcat(char *dest, const char *src);
 int _strcmp(const char *s1, const char *s2);
+char **duplicate_str_array(char **original);
+void concatenate_arrays(char ***dest, char **src);
 char *_strpbrk(const char *s, const char *accept);
 size_t _strspn(const char *s, const char *accept);
 char **_strtok(const char *str, const char *delim);
@@ -85,16 +91,16 @@ typedef struct _path
 } path_t;
 
 void _printenv(void);
+void print_path(path_t *list);
 void free_list(path_t **head);
 char *_getenv(const char *name);
 path_t *build_path(path_t **head);
-void print_path(path_t *list);
 
 /* numbers */
 
-void _reverse(char *buffer, size_t len);
-void _itoa(size_t n, char *s);
 int _atoi(const char *s);
+void _itoa(size_t n, char *s);
+void _reverse(char *buffer, size_t len);
 
 /* aliases */
 
@@ -112,19 +118,21 @@ typedef struct alias
 } alias_t;
 
 void free_aliases(alias_t **head);
-char *extract_value(const char *value);
 void print_aliases(const alias_t *head);
-int unalias(alias_t **head, char **command_line);
+int unalias(alias_t **head, char *command);
 char *get_alias(alias_t *head, const char *name);
-int handle_alias(alias_t **head, char **command_line);
+int handle_alias(alias_t **head, char *command_line);
 int print_alias(const alias_t *head, const char *name);
+void parse_aliases(const char *input, alias_t **aliases);
+void build_alias_cmd(char ***sub_command, char *alias_value);
 alias_t *add_alias(alias_t **head, const char *name, const char *value);
+void process_non_matching(alias_t *aliases, const char *non_matching, int end);
 
 /* builtin handlers */
 
+int _unsetenv(const char *name);
 int handle_cd(const char *pathname);
 int _setenv(const char *name, const char *value, int overwrite);
-int _unsetenv(const char *name);
 int handle_builtin(char **sub_command, char **commands, char *line,
 				   alias_t *aliases, path_t *path_list, int exit_code);
 int handle_exit(char *exit_code, int status,

--- a/string_array_handlers.c
+++ b/string_array_handlers.c
@@ -1,0 +1,68 @@
+#include "shell.h"
+
+/**
+ * duplicate_str_array - duplicate a string array
+ * @original: the original string
+ *
+ * Return: the duplicate string on success, else NULL if it fails
+ */
+char **duplicate_str_array(char **original)
+{
+	size_t size, i;
+	char **duplicate;
+
+	if (original == NULL)
+		return (NULL);
+
+	size = 0;
+	while (original[size] != NULL)
+		size++;
+
+	duplicate = (char **)malloc((size + 1) * sizeof(char *));
+	if (duplicate == NULL)
+		return (NULL);
+
+	for (i = 0; i < size; i++)
+	{
+		duplicate[i] = _strdup(original[i]);
+		if (duplicate[i] == NULL)
+		{
+			free_str(duplicate);
+			return (NULL);
+		}
+	}
+	duplicate[size] = NULL;
+
+	return (duplicate);
+}
+
+/**
+ * concatenate_arrays - appends the contents of one string array to another
+ * @dest: a pointer to the destination string array
+ * @src: the source string array (where to copy from)
+ */
+void concatenate_arrays(char ***dest, char **src)
+{
+	int i, src_length = 0, dest_length = 0;
+
+	if (src == NULL)
+		return; /* there's nothing concatenate */
+
+	while ((*dest)[dest_length] != NULL)
+		dest_length++;
+
+	while (src[src_length] != NULL)
+		src_length++;
+
+	*dest = realloc(*dest, (dest_length + src_length + 1) * sizeof(char *));
+	if (*dest == NULL)
+		return; /* memory allocation failed */
+
+	for (i = 0; i < src_length; i++)
+	{
+		(*dest)[dest_length + i] = _strdup(src[i]);
+	}
+
+	/* null terminate the string array */
+	(*dest)[dest_length + src_length] = NULL;
+}


### PR DESCRIPTION
In this update, the `alias` command can now handle more complex commands as its value, whereas previously it could only handle single command values.

It is now capable of handling cases such as the one presented below.

```bash
alias ls="ls --color=auto"
alias memchk='valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes -s'
.
.
alias l1="ls -1"
alias grep='grep --color=auto'
```

## Notes
At the moment, the shell is unable to process wildcards. It is not implemented yet.